### PR TITLE
Make scHPF a package

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,12 @@ The matrix should not have a header, but may be compressed with gzip or bzip2. W
 
 To preprocess the whitespace-delimited count matrix for a typical run, use the command:
 ```
-python SCHPF_HOME/scHPF/preprocessing.py --input UMICOUNT_MATRIX --prefix PREFIX -o OUTPUT_DIR -m 5 --whitelist GENE_WHITELIST
+python -m scHPF.preprocessing --input UMICOUNT_MATRIX --prefix PREFIX -o OUTPUT_DIR -m 5 --whitelist GENE_WHITELIST
 ```
 
 Where OUTPUT\_DIR does not need to exist and GENE\_WHITELIST is a two column, whitespace-delimited text file of ENSEMBL\_IDs and GENE\_SYMBOLs (see resources folder for an example).  As written, the command formats data for training and only includes genes that are (1) on the whitelist (eg protein coding) and (2) that we observe transcripts of in at least 5 cells.  After running this command, OUTPUT\_DIR should contain a matrix 'PREFIX.matrix.txt', a list of genes 'PREFIX.genes.txt', a preprocessing log file 'preprocessing.log.yaml', and a sparse-formatted training data file 'train.tsv'. More options and details for preprocessing can be viewed with 
 ```
-python SCHPF_HOME/scHPF/preprocessing.py -h
+python -m scHPF.preprocessing -h
 ```
 
 ### Training
@@ -46,17 +46,17 @@ Both computation time and memory requirements for scHPF scale with the number of
 
 Inference can be run using the train.py program.  For example:
 ```
-python SCHPF_HOME/scHPF/scHPF/train.py -i PREPROCESSING_OUTPUT_DIR -o TRAINING_OUTPUT_DIR -k 7 -t 5
+python -m scHPF.train -i PREPROCESSING_OUTPUT_DIR -o TRAINING_OUTPUT_DIR -k 7 -t 5
 ```
 This command performs approximate Bayesian inference on scHPF with, in this instance, seven factors and five different random initializations (in sequence). scHPF will automatically select the trial with the highest log likelikhood, and save the model in a subdirectory of TRAINING\_OUTPUT\_DIR with a name that states the value of k used and the id of the best run.  For example, the output of the previous command might be saved in 'TRAINING\_OUTPUT\_DIR/k007.run3;. More options for training can be viewed with
 ```
-python SCHPF_HOME/scHPF/train.py -h
+python -m scHPF.train -h
 ```
 
 ### Extracting scores
 To extract gene and cell scores from a trained scHPF model, run
 ```
-python SCHPF_HOME/scHPF/postprocessing.py score --param-dir PARAM_DIR
+python -m scHPF.postprocessing score --param-dir PARAM_DIR
 ```
 Where PARAM\_DIR is the subdirectory of TRAINING\_OUTPUT\_DIR in which the trained model was saved by the train.py command.  Cell and gene scores will be saved in 'TRAINING\_OUTPUT\_DIR/score/cell\_hnorm.txt' and 'TRAINING\_OUTPUT\_DIR/score/gene\_hnorm.txt'. 'cell\_hnorm.txt' is a cell by factor matrix of cell scores, where cells are in the same order as the original input matrix. 'gene\_hnorm.txt' is a gene by factor matrix of gene scores, where genes are in the same order as the genes in the PREFIX.genes.txt file produced by the preprocessing command.
 

--- a/scHPF/hpf_hyperparams.py
+++ b/scHPF/hpf_hyperparams.py
@@ -4,7 +4,7 @@ import yaml
 import numpy as np
 import tensorflow as tf
 
-from util import get_session
+from .util import get_session
 
 class HyperParams:
     """

--- a/scHPF/hpf_inference.py
+++ b/scHPF/hpf_inference.py
@@ -4,8 +4,8 @@ import numpy as np
 import tensorflow as tf
 import json
 
-from util import get_session, get_median_1d
-from hpf_metrics import HPFMetrics
+from .util import get_session, get_median_1d
+from .hpf_metrics import HPFMetrics
 
 
 class HPFInference(object):

--- a/scHPF/hpf_metrics.py
+++ b/scHPF/hpf_metrics.py
@@ -3,7 +3,7 @@
 import numpy as np
 import tensorflow as tf
 
-from util import get_median_1d
+from .util import get_median_1d
 
 
 class HPFMetrics(object):

--- a/scHPF/hpf_params.py
+++ b/scHPF/hpf_params.py
@@ -9,9 +9,9 @@ import numpy as np
 import tensorflow as tf
 from tensorflow.contrib.distributions import Poisson as tfPoisson
 
-from util import get_session, log_likelihood_poisson
-from hpf_hyperparams import HyperParams
-from hpf_inference import CAVICalculator
+from .util import get_session, log_likelihood_poisson
+from .hpf_hyperparams import HyperParams
+from .hpf_inference import CAVICalculator
 
 
 class HPFGamma:

--- a/scHPF/postprocessing.py
+++ b/scHPF/postprocessing.py
@@ -12,9 +12,9 @@ import numpy as np
 import pandas as pd
 import tensorflow as tf
 
-from util import get_session, create_sparse_tensor
-from scio import write_exp_matrix, load_sparse_exp
-from hpf_params import HyperParams, VariationalParams
+from .util import get_session, create_sparse_tensor
+from .scio import write_exp_matrix, load_sparse_exp
+from .hpf_params import HyperParams, VariationalParams
 
 
 class plots:

--- a/scHPF/preprocessing.py
+++ b/scHPF/preprocessing.py
@@ -12,7 +12,7 @@ import yaml
 import numpy as np
 import pandas as pd
 
-import scio
+import scHPF.scio as scio
 
 
 def filter_min_cells_expressing(df, genes, min_cells):

--- a/scHPF/train.py
+++ b/scHPF/train.py
@@ -12,11 +12,11 @@ import numpy as np
 import pandas # not used, but corrects weird collision with tensorflow
 import tensorflow as tf
 
-from scio import load_sparse_exp
-from util import create_sparse_tensor
-from hpf_params import HyperParams, VariationalParams
-from hpf_inference import HPFInference
-from postprocessing import factor_metrics, plots, write_factor_metrics
+from .scio import load_sparse_exp
+from .util import create_sparse_tensor
+from .hpf_params import HyperParams, VariationalParams
+from .hpf_inference import HPFInference
+from .postprocessing import factor_metrics, plots, write_factor_metrics
 
 
 def run_trials(indir, outdir, prefix, nfactors, a, ap, bp, c, cp, dp, ntrials=1,

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,19 @@
+import setuptools
+
+setuptools.setup(
+  name='scHPF',
+  description='Single-cell Hierarchical Poisson Factorization',
+  version='0.1',
+  url='https://www.github.com/simslab/scHPF',
+  license='GPLv3',
+  install_requires=[
+    'numpy',
+    'pandas',
+    'pyyaml',
+    'tensorflow',
+  ],
+  extras_require={
+    'plotting': ['seaborn']
+  },
+  packages=setuptools.find_packages(),
+)


### PR DESCRIPTION
This enables the following:

- installation, version tracking via pip: `pip install git+https://www.github.com/simslab/scHPF.git#egg=scHPF`
- automatic installation of dependencies
- access to the API from Python code (e.g. for more easily plugging into hyperparameter optimization)